### PR TITLE
FIX: replaced deprecated MArrayDataBuilder constructor

### DIFF
--- a/src/Utils.h
+++ b/src/Utils.h
@@ -715,7 +715,7 @@ template <typename TType>
 inline void setAttribute(MDataBlock& dataBlock, const Attribute& attribute, const std::vector<TType>& values)
 {
     MArrayDataHandle handle = dataBlock.outputArrayValue(attribute);
-    MArrayDataBuilder builder(attribute, unsigned(values.size()));
+    MArrayDataBuilder builder(nullptr, attribute, unsigned(values.size()));
     
     for (const auto& value : values)
     {


### PR DESCRIPTION
Hello @serguei-k 

I've found that this plugin was not compiling for maya 2019 / 2020 because the MArrayDataBuilder constructor was deprecated.

This is the fix I found to make it work.

In any case, thank you a lot for the nodes, they are really great!